### PR TITLE
Update gulpfile.babel.js

### DIFF
--- a/{{ cookiecutter.github_repository_name }}/gulpfile.babel.js
+++ b/{{ cookiecutter.github_repository_name }}/gulpfile.babel.js
@@ -13,7 +13,7 @@ gulp.task('test:js', testJs)
 
 gulp.task('build:js', ['test:js'], buildJs)
 gulp.task('build:sass', buildScss)
-gulp.task('build:static', ['clean:static:dist'], buildScss)
+gulp.task('build:static', ['clean:static:dist'], buildStatic)
 gulp.task('build', ['build:js', 'build:sass', 'build:static'])
 
 gulp.task('watch:js', ['build:js'], browserSync.reload)


### PR DESCRIPTION
Fix a bug in gulp tasks, where 'build:static' was mapped wrongly to buildScss task.
